### PR TITLE
accept integers as arguments for rotate, size and stack

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -44,13 +44,14 @@ export default Ember.Component.extend({
   rotateCssClass: computed('rotate', function() {
     let rotate = this.get('rotate');
     if (rotate) {
-      return rotate.match(/^fa-rotate/) ? rotate : `fa-rotate-${rotate}`;
+      return rotate.toString().match(/^fa-rotate/) ? rotate : `fa-rotate-${rotate}`;
     }
   }),
 
   sizeCssClass: computed('size', function() {
     let size = this.get('size');
     if (size) {
+      size = size.toString();
       if (size.match(/^fa-/)) {
         return size;
       } else {
@@ -69,6 +70,7 @@ export default Ember.Component.extend({
   stackCssClass: computed('stack', function() {
     let stack = this.get('stack');
     if (stack) {
+      stack = stack.toString();
       if (stack.match(/^fa-/)) {
         return stack;
       } else {

--- a/tests/integration/components/fa-icon-test.js
+++ b/tests/integration/components/fa-icon-test.js
@@ -79,6 +79,12 @@ test('fa-rotate 270', function(assert) {
   assert.ok($icon.hasClass('fa-rotate-270'));
 });
 
+test('fa-rotate as integer', function(assert) {
+  this.render(hbs`{{fa-icon icon="fa-credit-card" rotate=270}}`);
+  const $icon = this.$('i');
+  assert.ok($icon.hasClass('fa-rotate-270'));
+});
+
 test('fa-rotate no rotation', function(assert) {
   this.render(hbs`{{fa-icon icon="fa-credit-card"}}`);
   const $icon = this.$('i');
@@ -100,6 +106,12 @@ test('size 2x', function(assert) {
 
 test('size 2', function(assert) {
   this.render(hbs`{{fa-icon icon="fa-credit-card" size="2"}}`);
+  const $icon = this.$('i');
+  assert.ok($icon.hasClass('fa-2x'));
+});
+
+test('size 2 as integer', function(assert) {
+  this.render(hbs`{{fa-icon icon="fa-credit-card" size=2}}`);
   const $icon = this.$('i');
   assert.ok($icon.hasClass('fa-2x'));
 });
@@ -172,6 +184,12 @@ test('fa-stack 2x', function(assert) {
 
 test('fa-stack 2', function(assert) {
   this.render(hbs`{{fa-icon icon="fa-credit-card" stack="2"}}`);
+  const $icon = this.$('i');
+  assert.ok($icon.hasClass('fa-stack-2x'));
+});
+
+test('fa-stack 2 as integer', function(assert) {
+  this.render(hbs`{{fa-icon icon="fa-credit-card" stack=2}}`);
   const $icon = this.$('i');
   assert.ok($icon.hasClass('fa-stack-2x'));
 });


### PR DESCRIPTION
The examples in docs use integers for `rotate`, `size` and `stack` and I thought it would be better to allow integers as arguments rather than change the docs, I think in previous versions an integer was ok for `size` at least (was updating from some really old version and it worked back then).