### PR TITLE
[TEST]: fa-icon does not support bubbles on action

### DIFF
--- a/tests/acceptance/bubbles-test.js
+++ b/tests/acceptance/bubbles-test.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { test, module } from 'qunit';
+import startApp from 'dummy/tests/helpers/start-app';
+
+let application;
+
+module('Acceptance | bubbles fa-icon test', {
+    beforeEach: function() {
+        application = startApp();
+    },
+    afterEach: function() {
+        Ember.run(application, 'destroy');
+    }
+});
+
+test('bubbles attribute is respected on action', function(assert) {
+  visit('/');
+  click('.bubbles');
+  andThen(function() {
+      assert.equal(currentURL(), '/');
+  });
+});
+
+// the below works (ie bubbles will stop the browser from propagating the event)
+// <li><a href='#' class='bubbles' {{action 'trip' model bubbles=false}}>bubbles</a></li>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    actions: {
+        trip() {
+            // do something fun here
+        }
+    }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+    this.route('detail');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/detail.hbs
+++ b/tests/dummy/app/templates/detail.hbs
@@ -1,0 +1,1 @@
+<div class="detail">detail</div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -594,6 +594,9 @@
       <li>{{fa-icon icon='youtube' fixedWidth=true}} <span class="name">youtube</span></li>
       <li>{{fa-icon icon='youtube-play' fixedWidth=true}} <span class="name">youtube-play</span></li>
       <li>{{fa-icon icon='youtube-square' fixedWidth=true}} <span class="name">youtube-square</span></li>
+      {{#link-to 'detail' tagName='li'}}
+        <li>{{fa-icon icon='circle' classNames='bubbles' tagName='a' click=(action 'trip' model bubbles=false)}}<span class="name">bubbles</span></li>
+      {{/link-to}}
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This pull request shows a bug I found today when adding bubbles=false to an action on the fa-icon. In the acceptance test I show this in action. Interestingly a simple li w/ nested anchor works as the ember docs show (using action + bubbles=false).

```js
  <li><a href='#' class='bubbles' {{action 'trip' model bubbles=false}}>bubbles</a></li>
```

I couldn't understand when the handoff for actions occurred in the addon itself and could use your help to solve the issue shown.

I did my homework and found the commit below is when the readme was updated to show the actions example code. I just don't see any test code, or production code that prove it's wired up/supported.

https://github.com/martndemus/ember-cli-font-awesome/commit/ce788ae2ead565f067156e443ec6197c8f3306ce

Thank you in advance!