### PR TITLE
These fixes allow ember-cli-font-awsome to be used as a Nested addon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ module.exports = {
   },
 
   included: function(app, parentAddon) {
+     // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      this.app = app = app.app;
+    }
     this._super.included(app);
 
     var target = (parentAddon || app);


### PR DESCRIPTION
check out https://github.com/ember-cli/ember-cli/issues/3718 for a detailed error description for what happens currently without this patch.