### PR TITLE
Several index.js changes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,22 @@ and requires Ember CLI `>= 1.13.X`
 If you need compatibility with Ember `< 1.11.X` then you should try version
 `0.0.9`
 
-### Customize with sass/scss
+### Customize with Sass/Scss or Less
 
-If you are using the ember-cli-sass addon, you can opt-in to the Scss version
-of font-awesome by adding the following configuration in `ember-cli-build.js`:
+If you are using the ember-cli-sass or ember-cli-less addon, you can opt-in to
+the Scss or Less version of font-awesome by adding the following configuration
+in `ember-cli-build.js`:
 
 ```js
 var app = new EmberApp({
   emberCliFontAwesome: {
-    useScss: true
+    useScss: true, // for ember-cli-sass
+    useLess: true  // for ember-cli-less
   }
 });
 ```
 
-Then in your `app.scss`:
+Then in your `app.scss` or `app.less`:
 
 ```scss
 @import "font-awesome";

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ If you need compatibility with Ember `< 1.11.X` then you should try version
 
 ### Customize with sass/scss
 
-You can opt-in to the scss version of font-awesome. You can do this by adding
-the following configuration in `ember-cli-build.js`:
+If you are using the ember-cli-sass addon, you can opt-in to the Scss version
+of font-awesome by adding the following configuration in `ember-cli-build.js`:
 
 ```js
 var app = new EmberApp({
@@ -49,7 +49,7 @@ var app = new EmberApp({
 Then in your `app.scss`:
 
 ```scss
-@import "bower_components/font-awesome/scss/font-awesome";
+@import "font-awesome";
 ```
 
 ### Excluding assets

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ var app = new EmberApp({
 });
 ```
 
+In addition, you can configure the addon to _just_ exclude the font file assets by adding
+the following configuration in `ember-cli-build.js`:
+
+```js
+var app = new EmberApp({
+  emberCliFontAwesome: {
+    includeFontFiles: false
+  }
+});
+```
+
 ## Basic usage
 
 In your Handlebars templates:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ Then in your `app.scss`:
 @import "bower_components/font-awesome/scss/font-awesome";
 ```
 
+### Excluding assets
+
+You can configure the addon to _not_ import any assets (CSS or font files) by adding
+the following configuration in `ember-cli-build.js`:
+
+```js
+var app = new EmberApp({
+  emberCliFontAwesome: {
+    includeFontAwesomeAssets: false
+  }
+});
+```
+
 ## Basic usage
 
 In your Handlebars templates:

--- a/index.js
+++ b/index.js
@@ -20,11 +20,18 @@ module.exports = {
   },
 
   included: function(app, parentAddon) {
-     // see: https://github.com/ember-cli/ember-cli/issues/3718
+
+    // Quick fix for add-on nesting
+    // https://github.com/ember-cli/ember-cli/issues/3718
+    // https://github.com/aexmachina/ember-cli-sass/blob/v5.3.0/index.js#L73-L75
     if (typeof app.import !== 'function' && app.app) {
       this.app = app = app.app;
     }
-    this._super.included(app);
+
+
+    // https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-88122543
+    this._super.included.call(this, app);
+
 
     var target = (parentAddon || app);
     var options = target.options.emberCliFontAwesome || {};

--- a/index.js
+++ b/index.js
@@ -37,12 +37,25 @@ module.exports = {
     // Per the ember-cli documentation
     // http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
     var target = (parentAddon || app);
+    target.options = target.options || {}; // Ensures options exists for Scss below
     var options = target.options.emberCliFontAwesome || {};
 
 
     var faPath = path.join(target.bowerDirectory, 'font-awesome');
+    var scssPath = path.join(faPath, 'scss');
     var cssPath = path.join(faPath, 'css');
     var fontsPath = path.join(faPath, 'fonts');
+
+
+    // Ensure the font-awesome path is added to the ember-cli-sass addon options
+    // (Taking a cue from the Babel options above)
+    if (options.useScss) {
+      target.options.sassOptions = target.options.sassOptions || {};
+      target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];
+      if (target.options.sassOptions.includePaths.indexOf(scssPath) === -1) {
+        target.options.sassOptions.includePaths.push(scssPath);
+      }
+    }
 
 
     // Make sure font-awesome is available

--- a/index.js
+++ b/index.js
@@ -7,13 +7,16 @@ module.exports = {
   name: 'ember-cli-font-awesome',
 
   init: function(app) {
+
+    // Enable ES7 decorators via Babel
+    // https://www.npmjs.com/package/ember-computed-decorators#setup-with-addon
     this.options = this.options || {};
     this.options.babel = this.options.babel || {};
     this.options.babel.optional = this.options.babel.optional || [];
-
     if (this.options.babel.optional.indexOf('es7.decorators') === -1) {
       this.options.babel.optional.push('es7.decorators');
     }
+
   },
 
   included: function(app, parentAddon) {

--- a/index.js
+++ b/index.js
@@ -60,8 +60,12 @@ module.exports = {
     }
 
 
+    // Import the css when Sass is NOT used
     if (!options.useScss) {
-      target.import(path.join(cssPath, 'font-awesome.css'));
+      target.import({
+        development: path.join(cssPath, 'font-awesome.css'),
+        production: path.join(cssPath, 'font-awesome.min.css')
+      });
     }
 
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,16 @@ module.exports = {
     this._super.included.call(this, app);
 
 
+    // Per the ember-cli documentation
+    // http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
     var target = (parentAddon || app);
     var options = target.options.emberCliFontAwesome || {};
+
+
+    var faPath = path.join(target.bowerDirectory, 'font-awesome');
+    var cssPath = path.join(faPath, 'css');
+    var fontsPath = path.join(faPath, 'fonts');
+
 
     if (!('includeFontAwesomeAssets' in options)) {
       options.includeFontAwesomeAssets = true;
@@ -42,15 +50,15 @@ module.exports = {
 
     if (options.includeFontAwesomeAssets) {
       if (!options.useScss) {
-        target.import(target.bowerDirectory + "/font-awesome/css/font-awesome.css");
+        target.import(path.join(cssPath, 'font-awesome.css'));
       }
 
-      target.import(target.bowerDirectory + "/font-awesome/fonts/fontawesome-webfont.eot", { destDir: "fonts" });
-      target.import(target.bowerDirectory + "/font-awesome/fonts/fontawesome-webfont.svg", { destDir: "fonts" });
-      target.import(target.bowerDirectory + "/font-awesome/fonts/fontawesome-webfont.ttf", { destDir: "fonts" });
-      target.import(target.bowerDirectory + "/font-awesome/fonts/fontawesome-webfont.woff", { destDir: "fonts" });
-      target.import(target.bowerDirectory + "/font-awesome/fonts/fontawesome-webfont.woff2", { destDir: "fonts" });
-      target.import(target.bowerDirectory + "/font-awesome/fonts/FontAwesome.otf", { destDir: "fonts" });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -69,14 +69,14 @@ module.exports = {
     }
 
 
-    // Import the fonts when option not defined or enabled
+    // Import all files in the fonts folder when option not defined or enabled
     if (!('includeFontFiles' in options) || options.includeFontFiles) {
-      target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
+      fs.readdirSync(fontsPath).forEach(function(fontFilename){
+        target.import(
+          path.join(fontsPath, fontFilename),
+          { destDir:'/fonts' }
+        );
+      });
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 
 module.exports = {
@@ -42,6 +43,15 @@ module.exports = {
     var faPath = path.join(target.bowerDirectory, 'font-awesome');
     var cssPath = path.join(faPath, 'css');
     var fontsPath = path.join(faPath, 'fonts');
+
+
+    // Make sure font-awesome is available
+    if (!fs.existsSync(faPath)) {
+      throw new Error(
+        this.name + ': font-awesome is not available from bower (' + faPath + '), ' +
+        'install it into your project by running `bower install font-awesome --save`'
+      );
+    }
 
 
     if (!('includeFontAwesomeAssets' in options)) {

--- a/index.js
+++ b/index.js
@@ -37,12 +37,13 @@ module.exports = {
     // Per the ember-cli documentation
     // http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
     var target = (parentAddon || app);
-    target.options = target.options || {}; // Ensures options exists for Scss below
+    target.options = target.options || {}; // Ensures options exists for Scss/Less below
     var options = target.options.emberCliFontAwesome || {};
 
 
     var faPath = path.join(target.bowerDirectory, 'font-awesome');
     var scssPath = path.join(faPath, 'scss');
+    var lessPath = path.join(faPath, 'less');
     var cssPath = path.join(faPath, 'css');
     var fontsPath = path.join(faPath, 'fonts');
 
@@ -54,6 +55,17 @@ module.exports = {
       target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];
       if (target.options.sassOptions.includePaths.indexOf(scssPath) === -1) {
         target.options.sassOptions.includePaths.push(scssPath);
+      }
+    }
+
+
+    // Ensure the font-awesome path is added to the ember-cli-less addon options
+    // (Taking a cue from the Babel options above)
+    if (options.useLess) {
+      target.options.lessOptions = target.options.lessOptions || {};
+      target.options.lessOptions.paths = target.options.lessOptions.paths || [];
+      if (target.options.lessOptions.paths.indexOf(lessPath) === -1) {
+        target.options.lessOptions.paths.push(lessPath);
       }
     }
 
@@ -73,8 +85,8 @@ module.exports = {
     }
 
 
-    // Import the css when Sass is NOT used
-    if (!options.useScss) {
+    // Import the css when Sass and Less are NOT used
+    if (!options.useScss && !options.useLess) {
       target.import({
         development: path.join(cssPath, 'font-awesome.css'),
         production: path.join(cssPath, 'font-awesome.min.css')

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var path = require('path');
-var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-font-awesome',
@@ -44,15 +43,6 @@ module.exports = {
       target.import(target.bowerDirectory + "/font-awesome/fonts/FontAwesome.otf", { destDir: "fonts" });
     }
 
-  },
-
-  treeForStyles: function() {
-    var fontAwesomePath = path.join(this.app.bowerDirectory, 'font-awesome');
-    var fontAwesomeTree = new Funnel(this.treeGenerator(fontAwesomePath), {
-      srcDir: '/scss',
-      destDir: '/app/styles/font-awesome'
-    });
-
-    return fontAwesomeTree;
   }
+
 };

--- a/index.js
+++ b/index.js
@@ -69,12 +69,15 @@ module.exports = {
     }
 
 
-    target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
-    target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
-    target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
-    target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
-    target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
-    target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
+    // Import the fonts when option not defined or enabled
+    if (!('includeFontFiles' in options) || options.includeFontFiles) {
+      target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
+      target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
+    }
 
   }
 

--- a/index.js
+++ b/index.js
@@ -54,22 +54,23 @@ module.exports = {
     }
 
 
-    if (!('includeFontAwesomeAssets' in options)) {
-      options.includeFontAwesomeAssets = true;
+    // Early out if no assets should be imported
+    if ('includeFontAwesomeAssets' in options && !options.includeFontAwesomeAssets) {
+      return;
     }
 
-    if (options.includeFontAwesomeAssets) {
-      if (!options.useScss) {
-        target.import(path.join(cssPath, 'font-awesome.css'));
-      }
 
-      target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
-      target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
+    if (!options.useScss) {
+      target.import(path.join(cssPath, 'font-awesome.css'));
     }
+
+
+    target.import(path.join(fontsPath, 'fontawesome-webfont.eot'), { destDir: 'fonts' });
+    target.import(path.join(fontsPath, 'fontawesome-webfont.svg'), { destDir: 'fonts' });
+    target.import(path.join(fontsPath, 'fontawesome-webfont.ttf'), { destDir: 'fonts' });
+    target.import(path.join(fontsPath, 'fontawesome-webfont.woff'), { destDir: 'fonts' });
+    target.import(path.join(fontsPath, 'fontawesome-webfont.woff2'), { destDir: 'fonts' });
+    target.import(path.join(fontsPath, 'FontAwesome.otf'), { destDir: 'fonts' });
 
   }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "before": [
-      "ember-cli-sass"
+      "ember-cli-sass",
+      "ember-cli-less"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "ember-computed-decorators": "0.2.2"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "ember-cli-sass"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "broccoli-funnel": "^1.0.1",
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-sass": "^5.0.1",
     "ember-computed-decorators": "0.2.2"
   },
   "ember-addon": {


### PR DESCRIPTION
While exploring issue #72, I've made _several_ changes/commits to `index.js` to improve many aspects. Here is a list of the commits with descriptions that should explain everything (I feel like I wrote a noval...);

**Remove importing *.scss files into styles tree (entire treeForStyles hook)**
This should not be needed since users `@import` from within their `app.scss`. And since the README informs the user to import from the Bower directory, nothing really needs to be done by this addon to enable Sass support (user would just install the Sass addon and go from there).

**Add code comment about Babel decorators w/ link**
Added a couple comments to explain what is going on here, along with a link to the decorator addon showing this usage. And changed some code alignment things to improve visualization.

**Slight change to included _super call**
Made a slight change to the _super call for the included hook (per Stefan Penner’s comment). Also added a couple links explaining/showing the usage of this nested addon stuff.

**Use nodes path.join() to create paths**
Use nodes `path.join()` to create paths used for importing. That way there is no need to worry about extra or proper usage of slashes. And by creating path variables, it ensures the same path is used multiple times. Along with improving  code visualization.

**Add a friendly check for the font-awesome bower path**
I use this in a couple of my addons to insure the required Bower packages are installed. Simply checks the file system for the font-awesome path. If not available, a friendly error message is presented informing the user how to fix the problem. The `target.import()` later on would have failed anyway, so this is just an up-front check.

**Structure changes for the 'includeFontAwesomeAssets' option**
Rather than generating the `includeFontAwesomeAssets` option, and wrapping the `import()` stuff in an `if`, just look for the proper “exclude” criteria and `return` early (before any imports are performed). Also added documentation to the README about this option, not mentioned anywhere else.

**Target the proper css file depending on environment**
Since the font-awesome Bower package comes with both a minified and non-minified CSS file, import the proper one depending on what the build environment is.

**Add an 'includeFontFiles' option**
In spirit of the ‘includeFontAwesomeAssets’ option, add an additional option that targets just the font files. Also made note of this new option in the README.

**Import font files dynamically based on file system**
Instead of maintaining a static list of font files, use the nodes file system to dynamically get a list of _all_ files in the fonts folder. I consider this somewhat of future-proofing the addon, in case those files ever change.

**Adjust ember-cli-sass options to include font-awesome path**
When the `useScss` option is enabled, adjust the `ember-cli-sass` options to include the font-awesome path. That way the user can `@import "font-awesome";` instead of needing to include the bower path. Also make sure this addon is ran before the `ember-cli-sass` addon, so our option changes take effect. The README is also updated to better explain Sass support and show this new usage.

**Adjust ember-cli-less options to include font-awesome path**
Similar to the Sass support, when the `useLess` option is enabled, adjust the `ember-cli-less` options to include the font-awesome path. That way the user can just `@import "font-awesome";` in `app.less`. Also make sure this addon is ran before the `ember-cli-less` addon, so our option changes take effect. The README is also updated to add this new option and explain its usage.

Note: This fixes #72